### PR TITLE
Wrapped all C++ classes in an #ifdef __cplusplus

### DIFF
--- a/Libraries/HyTech_CAN/HyTech_CAN.h
+++ b/Libraries/HyTech_CAN/HyTech_CAN.h
@@ -83,6 +83,199 @@ typedef struct CAN_message_rcu_status_t {
     int16_t temperature;
 } CAN_msg_rcu_status;
 
+typedef struct CAN_message_fcu_status_t {
+    uint8_t state;
+    uint8_t flags;
+    uint8_t start_button_press_id;
+} CAN_msg_fcu_status;
+
+typedef struct CAN_message_fcu_readings_t {
+	uint16_t accelerator_pedal_raw_1;
+	uint16_t accelerator_pedal_raw_2;
+	uint16_t brake_pedal_raw;
+	int16_t temperature;
+} CAN_msg_fcu_readings;
+
+typedef struct CAN_message_bms_voltages_t {
+    uint16_t average_voltage;
+    uint16_t low_voltage;
+    uint16_t high_voltage;
+    uint16_t total_voltage;
+} CAN_message_bms_voltages_t;
+
+typedef struct CAN_message_bms_detailed_voltages_t {
+	uint8_t ic_id_group_id;
+    uint16_t voltage_0;
+    uint16_t voltage_1;
+    uint16_t voltage_2;
+} CAN_message_bms_detailed_voltages_t;
+
+typedef struct CAN_message_bms_temperatures_t {
+    int16_t average_temperature;
+    int16_t low_temperature;
+    int16_t high_temperature;
+} CAN_message_bms_temperatures_t;
+
+typedef struct CAN_message_bms_detailed_temperatures_t {
+	uint8_t ic_id;
+    int16_t temperature_0;
+    int16_t temperature_1;
+    int16_t temperature_2;
+} CAN_message_bms_detailed_temperatures_t;
+
+typedef struct CAN_message_bms_onboard_temperatures_t {
+    int16_t average_temperature;
+    int16_t low_temperature;
+    int16_t high_temperature;
+} CAN_message_bms_onboard_temperatures_t;
+
+typedef struct CAN_message_bms_onboard_detailed_temperatures_t {
+	uint8_t ic_id;
+    int16_t temperature_0;
+    int16_t temperature_1;
+} CAN_message_bms_onboard_detailed_temperatures_t;
+
+typedef struct CAN_message_bms_status_t {
+	uint8_t state;
+    uint16_t error_flags;
+    int16_t current;
+} CAN_message_bms_status_t;
+
+typedef struct CAN_message_bms_balancing_status_t {
+	uint8_t balancing_status[5];
+} CAN_message_bms_balancing_status_t;
+
+typedef struct CAN_message_ccu_status_t {
+    bool charger_enabled;
+} CAN_message_ccu_status_t;
+
+typedef struct CAN_message_mc_temperatures_1_t {
+    int16_t module_a_temperature;
+    int16_t module_b_temperature;
+    int16_t module_c_temperature;
+    int16_t gate_driver_board_temperature;
+} CAN_message_mc_temperatures_1_t;
+
+typedef struct CAN_message_mc_temperatures_2_t {
+    int16_t control_board_temperature;
+    int16_t rtd_1_temperature;
+    int16_t rtd_2_temperature;
+    int16_t rtd_3_temperature;
+} CAN_message_mc_temperatures_2_t;
+
+typedef struct CAN_message_mc_temperatures_3_t {
+    int16_t rtd_4_temperature;
+    int16_t rtd_5_temperature;
+    int16_t motor_temperature;
+    int16_t torque_shudder;
+} CAN_message_mc_temperatures_3_t;
+
+typedef struct CAN_message_mc_analog_input_voltages_t {
+    int16_t analog_input_1;
+    int16_t analog_input_2;
+    int16_t analog_input_3;
+    int16_t analog_input_4;
+} CAN_message_mc_analog_input_voltages_t;
+
+typedef struct CAN_message_mc_digital_input_status_t {
+    bool digital_input_1;
+    bool digital_input_2;
+    bool digital_input_3;
+    bool digital_input_4;
+    bool digital_input_5;
+    bool digital_input_6;
+    bool digital_input_7;
+    bool digital_input_8;
+} CAN_message_mc_digital_input_status_t;
+
+typedef struct CAN_message_mc_motor_position_information_t {
+    int16_t motor_angle;
+    int16_t motor_speed;
+    int16_t electrical_output_frequency;
+    int16_t delta_resolver_filtered;
+} CAN_message_mc_motor_position_information_t;
+
+typedef struct CAN_message_mc_current_information_t {
+    int16_t phase_a_current;
+    int16_t phase_b_current;
+    int16_t phase_c_current;
+    int16_t dc_bus_current;
+} CAN_message_mc_current_information_t;
+
+typedef struct CAN_message_mc_voltage_information_t {
+    int16_t dc_bus_voltage;
+    int16_t output_voltage;
+    int16_t phase_ab_voltage;
+    int16_t phase_bc_voltage;
+} CAN_message_mc_voltage_information_t;
+
+typedef struct CAN_message_mc_internal_states_t {
+    uint16_t vsm_state;
+    uint8_t inverter_state;
+    uint8_t relay_state;
+    uint8_t inverter_run_mode_discharge_state;
+    uint8_t inverter_command_mode;
+    uint8_t inverter_enable;
+    uint8_t direction_command;
+} CAN_message_mc_internal_states_t;
+
+typedef struct CAN_message_mc_fault_codes_t {
+    uint16_t post_fault_lo;
+    uint16_t post_fault_hi;
+    uint16_t run_fault_lo;
+    uint16_t run_fault_hi;
+} CAN_message_mc_fault_codes_t;
+
+typedef struct CAN_message_mc_torque_timer_information_t {
+    int16_t commanded_torque;
+    int16_t torque_feedback;
+    uint32_t power_on_timer;
+} CAN_message_mc_torque_timer_information_t;
+
+typedef struct CAN_message_mc_modulation_index_flux_weakening_output_information_t {
+    uint16_t modulation_index; // TODO Signed or Unsigned?
+    int16_t flux_weakening_output;
+    int16_t id_command;
+    int16_t iq_command;
+} CAN_message_mc_modulation_index_flux_weakening_output_information_t;
+
+typedef struct CAN_message_mc_firmware_information_t {
+    uint16_t eeprom_version_project_code;
+    uint16_t software_version;
+    uint16_t date_code_mmdd;
+    uint16_t date_code_yyyy;
+} CAN_message_mc_firmware_information_t;
+
+typedef struct CAN_message_mc_command_message_t {
+    int16_t torque_command;
+    int16_t angular_velocity;
+    bool direction;
+    uint8_t inverter_enable_discharge_enable;
+    int16_t commanded_torque_limit;
+} CAN_message_mc_command_message_t;
+
+typedef struct CAN_message_mc_read_write_parameter_command_t {
+    uint16_t parameter_address;
+    bool rw_command;
+    uint8_t reserved1;
+    uint32_t data;
+} CAN_message_mc_read_write_parameter_command_t;
+
+typedef struct CAN_message_mc_read_write_parameter_response_t {
+    uint16_t parameter_address;
+    bool write_success;
+    uint8_t reserved1;
+    uint32_t data;
+} CAN_message_mc_read_write_parameter_response_t;
+
+typedef struct CAN_message_fcu_accelerometer_values_t {
+   short XValue_x100;
+   short YValue_x100;
+   short ZValue_x100;
+} CAN_message_fcu_accelerometer_values_t;
+
+#ifdef __cplusplus
+
 class RCU_status {
     public:
         RCU_status();
@@ -110,12 +303,6 @@ class RCU_status {
         CAN_message_rcu_status_t message;
 };
 
-typedef struct CAN_message_fcu_status_t {
-    uint8_t state;
-    uint8_t flags;
-    uint8_t start_button_press_id;
-} CAN_msg_fcu_status;
-
 class FCU_status {
     public:
         FCU_status();
@@ -141,13 +328,6 @@ class FCU_status {
         CAN_message_fcu_status_t message;
 };
 
-typedef struct CAN_message_fcu_readings_t {
-	uint16_t accelerator_pedal_raw_1;
-	uint16_t accelerator_pedal_raw_2;
-	uint16_t brake_pedal_raw;
-	int16_t temperature;
-} CAN_msg_fcu_readings;
-
 class FCU_readings {
     public:
         FCU_readings();
@@ -167,13 +347,6 @@ class FCU_readings {
         CAN_message_fcu_readings_t message;
 };
 
-typedef struct CAN_message_bms_voltages_t {
-    uint16_t average_voltage;
-    uint16_t low_voltage;
-    uint16_t high_voltage;
-    uint16_t total_voltage;
-} CAN_message_bms_voltages_t;
-
 class BMS_voltages {
     public:
         BMS_voltages();
@@ -192,13 +365,6 @@ class BMS_voltages {
     private:
         CAN_message_bms_voltages_t message;
 };
-
-typedef struct CAN_message_bms_detailed_voltages_t {
-	uint8_t ic_id_group_id;
-    uint16_t voltage_0;
-    uint16_t voltage_1;
-    uint16_t voltage_2;
-} CAN_message_bms_detailed_voltages_t;
 
 class BMS_detailed_voltages {
     public:
@@ -223,12 +389,6 @@ class BMS_detailed_voltages {
         CAN_message_bms_detailed_voltages_t message;
 };
 
-typedef struct CAN_message_bms_temperatures_t {
-    int16_t average_temperature;
-    int16_t low_temperature;
-    int16_t high_temperature;
-} CAN_message_bms_temperatures_t;
-
 class BMS_temperatures {
     public:
         BMS_temperatures();
@@ -245,13 +405,6 @@ class BMS_temperatures {
     private:
         CAN_message_bms_temperatures_t message;
 };
-
-typedef struct CAN_message_bms_detailed_temperatures_t {
-	uint8_t ic_id;
-    int16_t temperature_0;
-    int16_t temperature_1;
-    int16_t temperature_2;
-} CAN_message_bms_detailed_temperatures_t;
 
 class BMS_detailed_temperatures {
     public:
@@ -274,12 +427,6 @@ class BMS_detailed_temperatures {
         CAN_message_bms_detailed_temperatures_t message;
 };
 
-typedef struct CAN_message_bms_onboard_temperatures_t {
-    int16_t average_temperature;
-    int16_t low_temperature;
-    int16_t high_temperature;
-} CAN_message_bms_onboard_temperatures_t;
-
 class BMS_onboard_temperatures {
     public:
         BMS_onboard_temperatures();
@@ -296,12 +443,6 @@ class BMS_onboard_temperatures {
     private:
         CAN_message_bms_onboard_temperatures_t message;
 };
-
-typedef struct CAN_message_bms_onboard_detailed_temperatures_t {
-	uint8_t ic_id;
-    int16_t temperature_0;
-    int16_t temperature_1;
-} CAN_message_bms_onboard_detailed_temperatures_t;
 
 class BMS_onboard_detailed_temperatures {
     public:
@@ -321,12 +462,6 @@ class BMS_onboard_detailed_temperatures {
     private:
         CAN_message_bms_onboard_detailed_temperatures_t message;
 };
-
-typedef struct CAN_message_bms_status_t {
-	uint8_t state;
-    uint16_t error_flags;
-    int16_t current;
-} CAN_message_bms_status_t;
 
 class BMS_status {
     public:
@@ -363,10 +498,6 @@ class BMS_status {
         CAN_message_bms_status_t message;
 };
 
-typedef struct CAN_message_bms_balancing_status_t {
-	uint8_t balancing_status[5];
-} CAN_message_bms_balancing_status_t;
-
 class BMS_balancing_status {
     public:
         BMS_balancing_status();
@@ -386,10 +517,6 @@ class BMS_balancing_status {
         CAN_message_bms_balancing_status_t message;
 };
 
-typedef struct CAN_message_ccu_status_t {
-    bool charger_enabled;
-} CAN_message_ccu_status_t;
-
 class CCU_status {
     public:
         CCU_status();
@@ -401,13 +528,6 @@ class CCU_status {
     private:
         CAN_message_ccu_status_t message;
 };
-
-typedef struct CAN_message_mc_temperatures_1_t {
-    int16_t module_a_temperature;
-    int16_t module_b_temperature;
-    int16_t module_c_temperature;
-    int16_t gate_driver_board_temperature;
-} CAN_message_mc_temperatures_1_t;
 
 class MC_temperatures_1 {
     public:
@@ -423,13 +543,6 @@ class MC_temperatures_1 {
         CAN_message_mc_temperatures_1_t message;
 };
 
-typedef struct CAN_message_mc_temperatures_2_t {
-    int16_t control_board_temperature;
-    int16_t rtd_1_temperature;
-    int16_t rtd_2_temperature;
-    int16_t rtd_3_temperature;
-} CAN_message_mc_temperatures_2_t;
-
 class MC_temperatures_2 {
     public:
         MC_temperatures_2();
@@ -443,13 +556,6 @@ class MC_temperatures_2 {
     private:
         CAN_message_mc_temperatures_2_t message;
 };
-
-typedef struct CAN_message_mc_temperatures_3_t {
-    int16_t rtd_4_temperature;
-    int16_t rtd_5_temperature;
-    int16_t motor_temperature;
-    int16_t torque_shudder;
-} CAN_message_mc_temperatures_3_t;
 
 class MC_temperatures_3 {
     public:
@@ -465,13 +571,6 @@ class MC_temperatures_3 {
         CAN_message_mc_temperatures_3_t message;
 };
 
-typedef struct CAN_message_mc_analog_input_voltages_t {
-    int16_t analog_input_1;
-    int16_t analog_input_2;
-    int16_t analog_input_3;
-    int16_t analog_input_4;
-} CAN_message_mc_analog_input_voltages_t;
-
 class MC_analog_input_voltages {
     public:
         MC_analog_input_voltages();
@@ -485,17 +584,6 @@ class MC_analog_input_voltages {
     private:
         CAN_message_mc_analog_input_voltages_t message;
 };
-
-typedef struct CAN_message_mc_digital_input_status_t {
-    bool digital_input_1;
-    bool digital_input_2;
-    bool digital_input_3;
-    bool digital_input_4;
-    bool digital_input_5;
-    bool digital_input_6;
-    bool digital_input_7;
-    bool digital_input_8;
-} CAN_message_mc_digital_input_status_t;
 
 class MC_digital_input_status {
     public:
@@ -515,13 +603,6 @@ class MC_digital_input_status {
         CAN_message_mc_digital_input_status_t message;
 };
 
-typedef struct CAN_message_mc_motor_position_information_t {
-    int16_t motor_angle;
-    int16_t motor_speed;
-    int16_t electrical_output_frequency;
-    int16_t delta_resolver_filtered;
-} CAN_message_mc_motor_position_information_t;
-
 class MC_motor_position_information {
     public:
         MC_motor_position_information();
@@ -535,13 +616,6 @@ class MC_motor_position_information {
     private:
         CAN_message_mc_motor_position_information_t message;
 };
-
-typedef struct CAN_message_mc_current_information_t {
-    int16_t phase_a_current;
-    int16_t phase_b_current;
-    int16_t phase_c_current;
-    int16_t dc_bus_current;
-} CAN_message_mc_current_information_t;
 
 class MC_current_information {
     public:
@@ -557,13 +631,6 @@ class MC_current_information {
         CAN_message_mc_current_information_t message;
 };
 
-typedef struct CAN_message_mc_voltage_information_t {
-    int16_t dc_bus_voltage;
-    int16_t output_voltage;
-    int16_t phase_ab_voltage;
-    int16_t phase_bc_voltage;
-} CAN_message_mc_voltage_information_t;
-
 class MC_voltage_information {
     public:
         MC_voltage_information();
@@ -577,16 +644,6 @@ class MC_voltage_information {
     private:
         CAN_message_mc_voltage_information_t message;
 };
-
-typedef struct CAN_message_mc_internal_states_t {
-    uint16_t vsm_state;
-    uint8_t inverter_state;
-    uint8_t relay_state;
-    uint8_t inverter_run_mode_discharge_state;
-    uint8_t inverter_command_mode;
-    uint8_t inverter_enable;
-    uint8_t direction_command;
-} CAN_message_mc_internal_states_t;
 
 class MC_internal_states {
     public:
@@ -611,13 +668,6 @@ class MC_internal_states {
     private:
         CAN_message_mc_internal_states_t message;
 };
-
-typedef struct CAN_message_mc_fault_codes_t {
-    uint16_t post_fault_lo;
-    uint16_t post_fault_hi;
-    uint16_t run_fault_lo;
-    uint16_t run_fault_hi;
-} CAN_message_mc_fault_codes_t;
 
 class MC_fault_codes {
     public:
@@ -697,12 +747,6 @@ class MC_fault_codes {
         CAN_message_mc_fault_codes_t message;
 };
 
-typedef struct CAN_message_mc_torque_timer_information_t {
-    int16_t commanded_torque;
-    int16_t torque_feedback;
-    uint32_t power_on_timer;
-} CAN_message_mc_torque_timer_information_t;
-
 class MC_torque_timer_information {
     public:
         MC_torque_timer_information();
@@ -715,13 +759,6 @@ class MC_torque_timer_information {
     private:
         CAN_message_mc_torque_timer_information_t message;
 };
-
-typedef struct CAN_message_mc_modulation_index_flux_weakening_output_information_t {
-    uint16_t modulation_index; // TODO Signed or Unsigned?
-    int16_t flux_weakening_output;
-    int16_t id_command;
-    int16_t iq_command;
-} CAN_message_mc_modulation_index_flux_weakening_output_information_t;
 
 class MC_modulation_index_flux_weakening_output_information {
     public:
@@ -737,13 +774,6 @@ class MC_modulation_index_flux_weakening_output_information {
         CAN_message_mc_modulation_index_flux_weakening_output_information_t message;
 };
 
-typedef struct CAN_message_mc_firmware_information_t {
-    uint16_t eeprom_version_project_code;
-    uint16_t software_version;
-    uint16_t date_code_mmdd;
-    uint16_t date_code_yyyy;
-} CAN_message_mc_firmware_information_t;
-
 class MC_firmware_information {
     public:
         MC_firmware_information();
@@ -757,14 +787,6 @@ class MC_firmware_information {
     private:
         CAN_message_mc_firmware_information_t message;
 };
-
-typedef struct CAN_message_mc_command_message_t {
-    int16_t torque_command;
-    int16_t angular_velocity;
-    bool direction;
-    uint8_t inverter_enable_discharge_enable;
-    int16_t commanded_torque_limit;
-} CAN_message_mc_command_message_t;
 
 class MC_command_message {
     public:
@@ -789,13 +811,6 @@ class MC_command_message {
         CAN_message_mc_command_message_t message;
 };
 
-typedef struct CAN_message_mc_read_write_parameter_command_t {
-    uint16_t parameter_address;
-    bool rw_command;
-    uint8_t reserved1;
-    uint32_t data;
-} CAN_message_mc_read_write_parameter_command_t;
-
 class MC_read_write_parameter_command {
     public:
         MC_read_write_parameter_command();
@@ -813,13 +828,6 @@ class MC_read_write_parameter_command {
         CAN_message_mc_read_write_parameter_command_t message;
 };
 
-typedef struct CAN_message_mc_read_write_parameter_response_t {
-    uint16_t parameter_address;
-    bool write_success;
-    uint8_t reserved1;
-    uint32_t data;
-} CAN_message_mc_read_write_parameter_response_t;
-
 class MC_read_write_parameter_response {
     public:
         MC_read_write_parameter_response();
@@ -832,12 +840,6 @@ class MC_read_write_parameter_response {
     private:
         CAN_message_mc_read_write_parameter_response_t message;
 };
-
-typedef struct CAN_message_fcu_accelerometer_values_t {
-   short XValue_x100;
-   short YValue_x100;
-   short ZValue_x100;
-} CAN_message_fcu_accelerometer_values_t;
 
 class FCU_accelerometer_values {
    public:
@@ -853,4 +855,5 @@ class FCU_accelerometer_values {
       CAN_message_fcu_accelerometer_values_t message;
 };
 
+#endif
 #endif


### PR DESCRIPTION
The header with CAN message structs contains both C structs and C++ classes. I separated the structs from the classes and wrapped the latter in conditional compilation so that the header will be usable from both C and C++.