### PR TITLE
Fixed curses terminal problem

### DIFF
--- a/Telemetry/telemetry_py/telemetry_lte_xbee.py
+++ b/Telemetry/telemetry_py/telemetry_lte_xbee.py
@@ -7,617 +7,614 @@ import codecs
 import struct
 import paho.mqtt.client as mqtt
 
-ecu_version = 0
+class TelemetryClient:
+    def __init__(self):
+        self.screen = None
+        self.ecu_version = 0
+        self.countGoodFrames = 0
+        self.countBadFrames = 0
+        
+        # Set up filenames for logging
+        timestamp = str(datetime.datetime.now())
+        self.filename = timestamp + ".txt"
+        self.filenameRaw = "raw " + timestamp + ".csv"
 
-screen = curses.initscr()
-countGoodFrames = 0
-countBadFrames = 0
 
-# Set up filenames for logging
-timestamp = str(datetime.datetime.now())
-filename = timestamp + ".txt"
-filenameRaw = "raw " + timestamp + ".csv"
+    def mqtt_connect(self, client, userdata, flags, rc):
+        client.subscribe("hytech_car/telemetry")
+        self.screen.addstr(0,47,' - CONNECTED')
+        client.publish("hytech_car/telemetry", "Python client connected")
 
-def mqtt_connect(client, userdata, flags, rc):
-    client.subscribe("hytech_car/telemetry")
-    screen.addstr(0,47,' - CONNECTED')
-    client.publish("hytech_car/telemetry", "Python client connected")
+    def mqtt_message(self, client, userdata, msg):
+        self.screen.addstr(0,59,' - RECEIVED')
 
-def mqtt_message(client, userdata, msg):
-    screen.addstr(0,59,' - RECEIVED')
-    global countGoodFrames
-    global countBadFrames
+        # TODO check format of incoming message for errors
+        timestamp = msg.payload[0:msg.payload.find(b',')]
+        frame = msg.payload[msg.payload.find(b',') + 1:-1]
+        frame = binascii.hexlify(frame)
+        data = unpack(frame)
 
-    # TODO check format of incoming message for errors
-    timestamp = msg.payload[0:msg.payload.find(b',')]
-    frame = msg.payload[msg.payload.find(b',') + 1:-1]
-    frame = binascii.hexlify(frame)
-    data = unpack(frame)
-
-    if data != -1:
-        with open(filenameRaw, "a") as f:
-            size = ord(data[4])
-            raw = binascii.hexlify(data[0]).upper() + "," + binascii.hexlify(data[5:5 + size]).upper()
-            f.write(str(datetime.datetime.now()) + ',' + raw + "\n")
-        countGoodFrames += 1
-        lines = decode(data)
-        with open(filename, "a") as f:
-            # TODO update to use timestamp sent over LTE instead of local timestamp
-            timestamp = str(datetime.datetime.now())
-            for line in lines:
-                updateScreen(line)
-                f.write(timestamp + ' ' + line + '\n')
-    else:
-        countBadFrames += 1
-
-def main():
-    if len(sys.argv) != 2:
-        print('Usage:')
-        print('telemetry_lte_xbee.py [fcu|mcu]\n')
-        quit()
-
-    if sys.argv[1] == 'fcu':
-        ecu_version = 0
-    else:
-        ecu_version = 1
-
-    screen.border('#', '#', '#', '#', 0, 0, 0, 0)
-    screen.addstr(0,5,'HYTECH RACING 2019 VEHICLE SERIAL DEBUGGER')
-    screen.addstr(3,5,'RMS INVERTER')
-    screen.addstr(4,5,'MODULE A TEMP: ')
-    screen.addstr(5,5,'MODULE B TEMP: ')
-    screen.addstr(6,5,'MODULE C TEMP: ')
-    screen.addstr(7,5,'GATE DRIVER BOARD TEMP: ')
-    screen.addstr(8,5,'RTD 4 TEMP: ')
-    screen.addstr(9,5,'RTD 5 TEMP: ')
-    screen.addstr(10,5,'MOTOR TEMP: ')
-    screen.addstr(11,5,'TORQUE SHUDDER: ')
-    screen.addstr(12,5,'MOTOR ANGLE: ')
-    screen.addstr(13,5,'MOTOR SPEED: ')
-    screen.addstr(14,5,'ELEC OUTPUT FREQ: ')
-    screen.addstr(15,5,'DELTA RESOLVER FILT: ')
-    screen.addstr(16,5,'PHASE A CURRENT: ')
-    screen.addstr(17,5,'PHASE B CURRENT: ')
-    screen.addstr(18,5,'PHASE C CURRENT: ')
-    screen.addstr(19,5,'DC BUS CURRENT: ')
-    screen.addstr(20,5,'DC BUS VOLTAGE: ')
-    screen.addstr(21,5,'OUTPUT VOLTAGE: ')
-    screen.addstr(22,5,'PHASE AB VOLTAGE: ')
-    screen.addstr(23,5,'PHASE BC VOLTAGE: ')
-    screen.addstr(24,5,'VSM STATE: ')
-    screen.addstr(25,5,'INVERTER STATE: ')
-    screen.addstr(26,5,'INVERTER RUN MODE: ')
-    screen.addstr(27,5,'INVERTER ACTIVE DISCHARGE STATE: ')
-    screen.addstr(28,5,'INVERTER COMMAND MODE: ')
-    screen.addstr(29,5,'INVERTER ENABLE: ')
-    screen.addstr(30,5,'INVERTER LOCKOUT: ')
-    screen.addstr(31,5,'DIRECTION COMMAND: ')
-    screen.addstr(32,5,'POST FAULT LO: ')
-    screen.addstr(33,5,'POST FAULT HI: ')
-    screen.addstr(34,5,'RUN FAULT LO: ')
-    screen.addstr(35,5,'RUN FAULT HI: ')
-    screen.addstr(36,5,'COMMANDED TORQUE: ')
-    screen.addstr(37,5,'TORQUE FEEDBACK: ')
-    screen.addstr(38,5,'RMS UPTIME: ')
-
-    screen.addstr(40,5,'GLV CURRENT READINGS')
-    screen.addstr(41,5,'ECU CURRENT: ')
-    screen.addstr(42,5,'COOLING CURRENT: ')
-
-    screen.addstr(3,55,'BATTERY MANAGEMENT SYSTEM')
-    screen.addstr(4,55,'BMS AVERAGE TEMPERATURE: ')
-    screen.addstr(5,55,'BMS LOW TEMPERATURE: ')
-    screen.addstr(6,55,'BMS HIGH TEMPERATURE: ')
-    screen.addstr(7,55,'BMS STATE: ')
-    screen.addstr(8,55,'BMS ERROR FLAGS: ')
-    screen.addstr(9,55,'BMS CURRENT: ')
-    screen.addstr(10,55,'BMS VOLTAGE AVERAGE: ')
-    screen.addstr(11,55,'BMS VOLTAGE LOW: ')
-    screen.addstr(12,55,'BMS VOLTAGE HIGH: ')
-    screen.addstr(13,55,'BMS VOLTAGE TOTAL: ')
-    screen.addstr(14,55,'BMS TOTAL CHARGE: ')
-    screen.addstr(15,55,'BMS TOTAL DISCHARGE: ')
-
-    if ecu_version == 0:
-        screen.addstr(17,55,'FRONT CONTROL UNIT')
-        screen.addstr(18,55,'FCU UPTIME: ')
-        screen.addstr(19,55,'FCU STATE: ')
-        screen.addstr(20,55,'START BUTTON ID: ')
-        screen.addstr(21,55,'FCU RAW TORQUE: ')
-        screen.addstr(22,55,'REQUESTED TORQUE: ')
-
-        screen.addstr(23,55,'FCU PEDAL ACCEL 1: ')
-        screen.addstr(24,55,'FCU PEDAL ACCEL 2: ')
-        screen.addstr(25,55,'FCU PEDAL BRAKE: ')
-        screen.addstr(26,55,'FCU BRAKE ACT: ')
-        screen.addstr(27,55,'FCU IMPLAUS ACCEL: ')
-        screen.addstr(28,55,'FCU IMPLAUS BRAKE: ')
-
-        # RCU messages are only needed if FCU is used
-        screen.addstr(30,55,'REAR CONTROL UNIT')
-        screen.addstr(31,55,'RCU UPTIME: ')
-        screen.addstr(32,55,'RCU STATE: ')
-        screen.addstr(33,55,'RCU FLAGS: ')
-        screen.addstr(34,55,'GLV BATT VOLTAGE: ')
-        screen.addstr(35,55,'RCU BMS FAULT: ')
-        screen.addstr(36,55,'RCU IMD FAULT: ')
-    else:
-        screen.addstr(17,55,'MAIN CONTROL UNIT')
-        screen.addstr(18,55,'MCU STATE: ')
-        screen.addstr(19,55,'MCU BMS FAULT: ')
-        screen.addstr(20,55,'MCU IMD FAULT: ')
-        screen.addstr(21,55,'MCU INVERTER POWER: ')
-        screen.addstr(22,55,'MCU SHUTDOWN ABOVE THRESH: ')
-        screen.addstr(23,55,'MCU TEMPERATURE: ')
-        screen.addstr(24,55,'MCU GLV VOLTAGE: ')
-
-        screen.addstr(25,55,'MCU PEDAL ACCEL 1: ')
-        screen.addstr(26,55,'MCU PEDAL ACCEL 2: ')
-        screen.addstr(27,55,'MCU PEDAL BRAKE: ')
-        screen.addstr(28,55,'MCU BRAKE ACT: ')
-        screen.addstr(29,55,'MCU IMPLAUS ACCEL: ')
-        screen.addstr(30,55,'MCU IMPLAUS BRAKE: ')
-        screen.addstr(31,55,'MCU TORQUE MAP MODE: ')
-        screen.addstr(32,55,'REQUESTED TORQUE: ')
-
-    screen.addstr(3,105,'BATTERY MANAGEMENT SYSTEM DETAILED VOLTAGES')
-    screen.addstr(4,105,'IC 0 CELL 0: ')
-    screen.addstr(5,105,'IC 0 CELL 1: ')
-    screen.addstr(6,105,'IC 0 CELL 2: ')
-    screen.addstr(7,105,'IC 0 CELL 3: ')
-    screen.addstr(8,105,'IC 0 CELL 4: ')
-    screen.addstr(9,105,'IC 0 CELL 5: ')
-    screen.addstr(10,105,'IC 0 CELL 6: ')
-    screen.addstr(11,105,'IC 0 CELL 7: ')
-    screen.addstr(12,105,'IC 0 CELL 8: ')
-
-    screen.addstr(14,105,'IC 1 CELL 0: ')
-    screen.addstr(15,105,'IC 1 CELL 1: ')
-    screen.addstr(16,105,'IC 1 CELL 2: ')
-    screen.addstr(17,105,'IC 1 CELL 3: ')
-    screen.addstr(18,105,'IC 1 CELL 4: ')
-    screen.addstr(19,105,'IC 1 CELL 5: ')
-    screen.addstr(20,105,'IC 1 CELL 6: ')
-    screen.addstr(21,105,'IC 1 CELL 7: ')
-    screen.addstr(22,105,'IC 1 CELL 8: ')
-
-    screen.addstr(24,105,'IC 2 CELL 0: ')
-    screen.addstr(25,105,'IC 2 CELL 1: ')
-    screen.addstr(26,105,'IC 2 CELL 2: ')
-    screen.addstr(27,105,'IC 2 CELL 3: ')
-    screen.addstr(28,105,'IC 2 CELL 4: ')
-    screen.addstr(29,105,'IC 2 CELL 5: ')
-    screen.addstr(30,105,'IC 2 CELL 6: ')
-    screen.addstr(31,105,'IC 2 CELL 7: ')
-    screen.addstr(32,105,'IC 2 CELL 8: ')
-
-    screen.addstr(34,105,'IC 3 CELL 0: ')
-    screen.addstr(35,105,'IC 3 CELL 1: ')
-    screen.addstr(36,105,'IC 3 CELL 2: ')
-    screen.addstr(37,105,'IC 3 CELL 3: ')
-    screen.addstr(38,105,'IC 3 CELL 4: ')
-    screen.addstr(39,105,'IC 3 CELL 5: ')
-    screen.addstr(40,105,'IC 3 CELL 6: ')
-    screen.addstr(41,105,'IC 3 CELL 7: ')
-    screen.addstr(42,105,'IC 3 CELL 8: ')
-
-    screen.addstr(4,130,'IC 4 CELL 0: ')
-    screen.addstr(5,130,'IC 4 CELL 1: ')
-    screen.addstr(6,130,'IC 4 CELL 2: ')
-    screen.addstr(7,130,'IC 4 CELL 3: ')
-    screen.addstr(8,130,'IC 4 CELL 4: ')
-    screen.addstr(9,130,'IC 4 CELL 5: ')
-    screen.addstr(10,130,'IC 4 CELL 6: ')
-    screen.addstr(11,130,'IC 4 CELL 7: ')
-    screen.addstr(12,130,'IC 4 CELL 8: ')
-
-    screen.addstr(14,130,'IC 5 CELL 0: ')
-    screen.addstr(15,130,'IC 5 CELL 1: ')
-    screen.addstr(16,130,'IC 5 CELL 2: ')
-    screen.addstr(17,130,'IC 5 CELL 3: ')
-    screen.addstr(18,130,'IC 5 CELL 4: ')
-    screen.addstr(19,130,'IC 5 CELL 5: ')
-    screen.addstr(20,130,'IC 5 CELL 6: ')
-    screen.addstr(21,130,'IC 5 CELL 7: ')
-    screen.addstr(22,130,'IC 5 CELL 8: ')
-
-    screen.addstr(24,130,'IC 6 CELL 0: ')
-    screen.addstr(25,130,'IC 6 CELL 1: ')
-    screen.addstr(26,130,'IC 6 CELL 2: ')
-    screen.addstr(27,130,'IC 6 CELL 3: ')
-    screen.addstr(28,130,'IC 6 CELL 4: ')
-    screen.addstr(29,130,'IC 6 CELL 5: ')
-    screen.addstr(30,130,'IC 6 CELL 6: ')
-    screen.addstr(31,130,'IC 6 CELL 7: ')
-    screen.addstr(32,130,'IC 6 CELL 8: ')
-
-    screen.addstr(34,130,'IC 7 CELL 0: ')
-    screen.addstr(35,130,'IC 7 CELL 1: ')
-    screen.addstr(36,130,'IC 7 CELL 2: ')
-    screen.addstr(37,130,'IC 7 CELL 3: ')
-    screen.addstr(38,130,'IC 7 CELL 4: ')
-    screen.addstr(39,130,'IC 7 CELL 5: ')
-    screen.addstr(40,130,'IC 7 CELL 6: ')
-    screen.addstr(41,130,'IC 7 CELL 7: ')
-    screen.addstr(42,130,'IC 7 CELL 8: ')
-
-    screen.addstr(3,155,'BATTERY MANAGEMENT SYSTEM DETAILED TEMPERATURES')
-    screen.addstr(4,155,'IC 0 THERM 0: ')
-    screen.addstr(5,155,'IC 0 THERM 1: ')
-    screen.addstr(6,155,'IC 0 THERM 2: ')
-
-    screen.addstr(8,155,'IC 1 THERM 0: ')
-    screen.addstr(9,155,'IC 1 THERM 1: ')
-    screen.addstr(10,155,'IC 1 THERM 2: ')
-
-    screen.addstr(12,155,'IC 2 THERM 0: ')
-    screen.addstr(13,155,'IC 2 THERM 1: ')
-    screen.addstr(14,155,'IC 2 THERM 2: ')
-
-    screen.addstr(16,155,'IC 3 THERM 0: ')
-    screen.addstr(17,155,'IC 3 THERM 1: ')
-    screen.addstr(18,155,'IC 3 THERM 2: ')
-
-    screen.addstr(4,180,'IC 4 THERM 0: ')
-    screen.addstr(5,180,'IC 4 THERM 1: ')
-    screen.addstr(6,180,'IC 4 THERM 2: ')
-
-    screen.addstr(8,180,'IC 5 THERM 0: ')
-    screen.addstr(9,180,'IC 5 THERM 1: ')
-    screen.addstr(10,180,'IC 5 THERM 2: ')
-
-    screen.addstr(12,180,'IC 6 THERM 0: ')
-    screen.addstr(13,180,'IC 6 THERM 1: ')
-    screen.addstr(14,180,'IC 6 THERM 2: ')
-
-    screen.addstr(16,180,'IC 7 THERM 0: ')
-    screen.addstr(17,180,'IC 7 THERM 1: ')
-    screen.addstr(18,180,'IC 7 THERM 2: ')
-
-    screen.addstr(20,155,'BATTERY MANAGEMENT SYSTEM BALANCING STATUS')
-    screen.addstr(21,160,'C0')
-    screen.addstr(21,165,'C1')
-    screen.addstr(21,170,'C2')
-    screen.addstr(21,175,'C3')
-    screen.addstr(21,180,'C4')
-    screen.addstr(21,185,'C5')
-    screen.addstr(21,190,'C6')
-    screen.addstr(21,195,'C7')
-    screen.addstr(21,200,'C8')
-    screen.addstr(22,155,'IC0')
-    screen.addstr(23,155,'IC1')
-    screen.addstr(24,155,'IC2')
-    screen.addstr(25,155,'IC3')
-    screen.addstr(26,155,'IC4')
-    screen.addstr(27,155,'IC5')
-    screen.addstr(28,155,'IC6')
-    screen.addstr(29,155,'IC7')
-
-    curses.wrapper(live)
-    curses.endwin()
-
-def live(screen):
-    # Set up mqtt connection
-    client = mqtt.Client()
-    client.connect("hytech-telemetry.ryangallaway.me", 1883, 60)
-    client.on_connect = mqtt_connect
-    client.on_message = mqtt_message
-    client.loop_start()
-    
-    screen.nodelay(True)
-
-    # Write CSV Header
-    with open(filenameRaw, "a") as f:
-        f.write("timestamp,CAN ID,msg\n")
-    
-    # Wait for q to quit
-    char = screen.getch()
-    while char != ord('q') and char != ord('Q'):
-        char = screen.getch()
-
-    # Time to quit, disconnect MQTT
-    client.loop_stop()
-    client.disconnect() # TODO unsure if this should be called
-
-    # Write out statistics
-    with open(filename, "a") as f:
-        f.write("Processed " + str(countGoodFrames) + " good frames - ignored " + str(countBadFrames) + " bad frames")
-
-def updateScreen(incomingLine):
-    if ('MODULE A TEMP' in incomingLine):
-        clearLine(4,5)
-        screen.addstr(4,5,incomingLine)
-    if ('MODULE B TEMP' in incomingLine):
-        clearLine(5,5)
-        screen.addstr(5,5,incomingLine)
-    if ('MODULE C TEMP' in incomingLine):
-        clearLine(6,5)
-        screen.addstr(6,5,incomingLine)
-    if ('GATE DRIVER BOARD TEMP' in incomingLine):
-        clearLine(7,5)
-        screen.addstr(7,5,incomingLine)
-    if ('RTD 4 TEMP' in incomingLine):
-        clearLine(8,5)
-        screen.addstr(8,5,incomingLine)
-    if ('RTD 5 TEMP' in incomingLine):
-        clearLine(9,5)
-        screen.addstr(9,5,incomingLine)
-    if ('MOTOR TEMP' in incomingLine):
-        clearLine(10,5)
-        screen.addstr(10,5,incomingLine)
-    if ('TORQUE SHUDDER' in incomingLine):
-        clearLine(11,5)
-        screen.addstr(11,5,incomingLine)
-    if ('MOTOR ANGLE' in incomingLine):
-        clearLine(12,5)
-        screen.addstr(12,5,incomingLine)
-    if ('MOTOR SPEED' in incomingLine):
-        clearLine(13,5)
-        screen.addstr(13,5,incomingLine)
-    if ('ELEC OUTPUT FREQ' in incomingLine):
-        clearLine(14,5)
-        screen.addstr(14,5,incomingLine)
-    if ('DELTA RESOLVER FILT' in incomingLine):
-        clearLine(15,5)
-        screen.addstr(15,5,incomingLine)
-    if ('PHASE A CURRENT' in incomingLine):
-        clearLine(16,5)
-        screen.addstr(16,5,incomingLine)
-    if ('PHASE B CURRENT' in incomingLine):
-        clearLine(17,5)
-        screen.addstr(17,5,incomingLine)
-    if ('PHASE C CURRENT' in incomingLine):
-        clearLine(18,5)
-        screen.addstr(18,5,incomingLine)
-    if ('DC BUS CURRENT' in incomingLine):
-        clearLine(19,5)
-        screen.addstr(19,5,incomingLine)
-    if ('DC BUS VOLTAGE' in incomingLine):
-        clearLine(20,5)
-        screen.addstr(20,5,incomingLine)
-    if ('OUTPUT VOLTAGE' in incomingLine):
-        clearLine(21,5)
-        screen.addstr(21,5,incomingLine)
-    if ('PHASE AB VOLTAGE' in incomingLine):
-        clearLine(22,5)
-        screen.addstr(22,5,incomingLine)
-    if ('PHASE BC VOLTAGE' in incomingLine):
-        clearLine(23,5)
-        screen.addstr(23,5,incomingLine)
-    if ('VSM STATE' in incomingLine):
-        clearLine(24,5)
-        screen.addstr(24,5,incomingLine)
-    if ('INVERTER STATE' in incomingLine):
-        clearLine(25,5)
-        screen.addstr(25,5,incomingLine)
-    if ('INVERTER RUN MODE' in incomingLine):
-        clearLine(26,5)
-        screen.addstr(26,5,incomingLine)
-    if ('INVERTER ACTIVE DISCHARGE STATE' in incomingLine):
-        clearLine(27,5)
-        screen.addstr(27,5,incomingLine)
-    if ('INVERTER COMMAND MODE' in incomingLine):
-        clearLine(28,5)
-        screen.addstr(28,5,incomingLine)
-    if ('INVERTER ENABLE' in incomingLine):
-        clearLine(29,5)
-        screen.addstr(29,5,incomingLine)
-    if ('INVERTER LOCKOUT' in incomingLine):
-        clearLine(30,5)
-        screen.addstr(30,5,incomingLine)
-    if ('DIRECTION COMMAND' in incomingLine):
-        clearLine(31,5)
-        screen.addstr(31,5,incomingLine)
-    if ('POST FAULT LO' in incomingLine):
-        clearLine(32,5)
-        screen.addstr(32,5,incomingLine)
-    if ('POST FAULT HI' in incomingLine):
-        clearLine(33,5)
-        screen.addstr(33,5,incomingLine)
-    if ('RUN FAULT LO' in incomingLine):
-        clearLine(34,5)
-        screen.addstr(34,5,incomingLine)
-    if ('RUN FAULT HI' in incomingLine):
-        clearLine(35,5)
-        screen.addstr(35,5,incomingLine)
-    if ('COMMANDED TORQUE:' in incomingLine):
-        clearLine(36,5)
-        screen.addstr(36,5,incomingLine)
-    if ('TORQUE FEEDBACK' in incomingLine):
-        clearLine(37,5)
-        screen.addstr(37,5,incomingLine)
-    if ('RMS UPTIME' in incomingLine):
-        clearLine(38,5)
-        screen.addstr(38,5,incomingLine)
-    if ('ECU CURRENT' in incomingLine):
-        clearLine(41,5)
-        screen.addstr(41,5,incomingLine)
-    if ('COOLING CURRENT' in incomingLine):
-        clearLine(42,5)
-        screen.addstr(42,5,incomingLine)
-    if ('BMS AVERAGE TEMPERATURE' in incomingLine):
-        clearLine(4,55)
-        screen.addstr(4,55,incomingLine)
-    if ('BMS LOW TEMPERATURE' in incomingLine):
-        clearLine(5,55)
-        screen.addstr(5,55,incomingLine)
-    if ('BMS HIGH TEMPERATURE' in incomingLine):
-        clearLine(6,55)
-        screen.addstr(6,55,incomingLine)
-    if ('BMS STATE' in incomingLine):
-        clearLine(7,55)
-        screen.addstr(7,55,incomingLine)
-    if ('BMS ERROR FLAGS' in incomingLine):
-        clearLine(8,55)
-        screen.addstr(8,55,incomingLine)
-    if ('BMS CURRENT' in incomingLine):
-        clearLine(9,55)
-        screen.addstr(9,55,incomingLine)
-    if ('BMS VOLTAGE AVERAGE' in incomingLine):
-        clearLine(10,55)
-        screen.addstr(10,55,incomingLine)
-    if ('BMS VOLTAGE LOW' in incomingLine):
-        clearLine(11,55)
-        screen.addstr(11,55,incomingLine)
-    if ('BMS VOLTAGE HIGH' in incomingLine):
-        clearLine(12,55)
-        screen.addstr(12,55,incomingLine)
-    if ('BMS VOLTAGE TOTAL' in incomingLine):
-        clearLine(13,55)
-        screen.addstr(13,55,incomingLine)
-    if ('BMS TOTAL CHARGE' in incomingLine):
-        clearLine(14,55)
-        screen.addstr(14,55,incomingLine)
-    if ('BMS TOTAL DISCHARGE' in incomingLine):
-        clearLine(15,55)
-        screen.addstr(15,55,incomingLine)
-    if ('FCU UPTIME' in incomingLine or 'MCU STATE' in incomingLine):
-        clearLine(18,55)
-        screen.addstr(18,55,incomingLine)
-    if ('FCU STATE' in incomingLine or 'MCU BMS FAULT' in incomingLine):
-        clearLine(19,55)
-        screen.addstr(19,55,incomingLine)
-    if ('FCU START BUTTON ID' in incomingLine or 'MCU IMD FAULT' in incomingLine):
-        clearLine(20,55)
-        screen.addstr(20,55,incomingLine)
-    if ('FCU RAW TORQUE' in incomingLine or 'MCU INVERTER POWER' in incomingLine):
-        clearLine(21,55)
-        screen.addstr(21,55,incomingLine)
-    if ('REQUESTED TORQUE' in incomingLine):
-        if ecu_version == 0:
-            clearLine(22,55)
-            screen.addstr(22,55,incomingLine)
+        if data != -1:
+            with open(self.filenameRaw, "a") as f:
+                size = ord(data[4])
+                raw = binascii.hexlify(data[0]).upper() + "," + binascii.hexlify(data[5:5 + size]).upper()
+                f.write(str(datetime.datetime.now()) + ',' + raw + "\n")
+            self.countGoodFrames += 1
+            lines = decode(data)
+            with open(self.filename, "a") as f:
+                # TODO update to use timestamp sent over LTE instead of local timestamp
+                timestamp = str(datetime.datetime.now())
+                for line in lines:
+                    self.updateScreen(line)
+                    f.write(timestamp + ' ' + line + '\n')
         else:
-            clearLine(32,55)
-            screen.addstr(32,55,incomingLine)
-    if ('MCU SHUTDOWN ABOVE THRESH' in incomingLine):
-        clearLine(22,55)
-        screen.addstr(22,55,incomingLine)
-    if ('FCU PEDAL ACCEL 1' in incomingLine or 'MCU TEMPERATURE' in incomingLine):
-        clearLine(23,55)
-        screen.addstr(23,55,incomingLine)
-    if ('FCU PEDAL ACCEL 2' in incomingLine or 'MCU GLV VOLTAGE' in incomingLine):
-        clearLine(24,55)
-        screen.addstr(24,55,incomingLine)
-    if ('FCU PEDAL BRAKE' in incomingLine or 'MCU PEDAL ACCEL 1' in incomingLine):
-        clearLine(25,55)
-        screen.addstr(25,55,incomingLine)
-    if ('FCU BRAKE ACT' in incomingLine or 'MCU PEDAL ACCEL 2' in incomingLine):
-        clearLine(26,55)
-        screen.addstr(26,55,incomingLine)
-    if ('FCU IMPLAUS ACCEL' in incomingLine or 'MCU PEDAL BRAKE' in incomingLine):
-        clearLine(27,55)
-        screen.addstr(27,55,incomingLine)
-    if ('FCU IMPLAUS BRAKE' in incomingLine or 'MCU BRAKE ACT' in incomingLine):
-        clearLine(28,55)
-        screen.addstr(28,55,incomingLine)
-    if ('MCU IMPLAUS ACCEL' in incomingLine):
-        clearLine(29, 55)
-        screen.addstr(29, 55, incomingLine)
-    if ('MCU IMPLAUS BRAKE' in incomingLine):
-        clearLine(30, 55)
-        screen.addstr(30, 55, incomingLine)
-    if ('RCU UPTIME' in incomingLine or 'MCU TORQUE MAP MODE' in incomingLine):
-        clearLine(31,55)
-        screen.addstr(31,55,incomingLine)
-    if ('RCU STATE' in incomingLine):
-        clearLine(32,55)
-        screen.addstr(32,55,incomingLine)
-    if ('RCU FLAGS' in incomingLine):
-        clearLine(33,55)
-        screen.addstr(33,55,incomingLine)
-    if ('GLV BATT VOLTAGE' in incomingLine):
-        clearLine(34,55)
-        screen.addstr(34,55,incomingLine)
-    if ('RCU BMS FAULT' in incomingLine):
-        clearLine(35,55)
-        screen.addstr(35,55,incomingLine)
-    if ('RCU IMD FAULT' in incomingLine):
-        clearLine(36,55)
-        screen.addstr(36,55,incomingLine)
-    if ('IC 0 C' in incomingLine):
-        row = 4 + int(incomingLine[10])
-        clearLineShort(row,105)
-        screen.addstr(row,105,incomingLine)
-    if ('IC 1 C' in incomingLine):
-        row = 14 + int(incomingLine[10])
-        clearLineShort(row,105)
-        screen.addstr(row,105,incomingLine)
-    if ('IC 2 C' in incomingLine):
-        row = 24 + int(incomingLine[10])
-        clearLineShort(row,105)
-        screen.addstr(row,105,incomingLine)
-    if ('IC 3 C' in incomingLine):
-        row = 34 + int(incomingLine[10])
-        clearLineShort(row,105)
-        screen.addstr(row,105,incomingLine)
-    if ('IC 4 C' in incomingLine):
-        row = 4 + int(incomingLine[10])
-        clearLineShort(row,130)
-        screen.addstr(row,130,incomingLine)
-    if ('IC 5 C' in incomingLine):
-        row = 14 + int(incomingLine[10])
-        clearLineShort(row,130)
-        screen.addstr(row,130,incomingLine)
-    if ('IC 6 C' in incomingLine):
-        row = 24 + int(incomingLine[10])
-        clearLineShort(row,130)
-        screen.addstr(row,130,incomingLine)
-    if ('IC 7 C' in incomingLine):
-        row = 34 + int(incomingLine[10])
-        clearLineShort(row,130)
-        screen.addstr(row,130,incomingLine)
-    if ('IC 0 T' in incomingLine):
-        row = 4 + int(incomingLine[11])
-        clearLineShort(row,155)
-        screen.addstr(row,155,incomingLine)
-    if ('IC 1 T' in incomingLine):
-        row = 8 + int(incomingLine[11])
-        clearLineShort(row,155)
-        screen.addstr(row,155,incomingLine)
-    if ('IC 2 T' in incomingLine):
-        row = 12 + int(incomingLine[11])
-        clearLineShort(row,155)
-        screen.addstr(row,155,incomingLine)
-    if ('IC 3 T' in incomingLine):
-        row = 16 + int(incomingLine[11])
-        clearLineShort(row,155)
-        screen.addstr(row,155,incomingLine)
-    if ('IC 4 T' in incomingLine):
-        row = 4 + int(incomingLine[11])
-        clearLineShort(row,180)
-        screen.addstr(row,180,incomingLine)
-    if ('IC 5 T' in incomingLine):
-        row = 8 + int(incomingLine[11])
-        clearLineShort(row,180)
-        screen.addstr(row,180,incomingLine)
-    if ('IC 6 T' in incomingLine):
-        row = 12 + int(incomingLine[11])
-        clearLineShort(row,180)
-        screen.addstr(row,180,incomingLine)
-    if ('IC 7 T' in incomingLine):
-        row = 16 + int(incomingLine[11])
-        clearLineShort(row,180)
-        screen.addstr(row,180,incomingLine)
-    if ('BAL' in incomingLine): # format: BAL IC# CELL# [ON|OFF]
-        row = 22 + int(incomingLine[incomingLine.index('IC') + 2])
-        col = 160 + (int(incomingLine[incomingLine.index('CELL') + 4]) * 5)
-        clearLineBal(row, col)
-        if 'ON' in incomingLine:
-            screen.addstr(row, col, 'BAL')
-    screen.refresh()
+            self.countBadFrames += 1
 
-def clearLine(y, x):
-    blanks = '                                                  '
-    screen.addstr(y,x,blanks)
+    def setupScreen(self, initScreen):
+        self.screen = initScreen
 
-def clearLineShort(y, x):
-    blanks = '                      '
-    screen.addstr(y,x,blanks)
+        if sys.argv[1] == 'fcu':
+            self.ecu_version = 0
+        else:
+            self.ecu_version = 1
 
-def clearLineBal(y, x):
-    blanks = '   '
-    screen.addstr(y,x,blanks)
+        self.screen.border('#', '#', '#', '#', 0, 0, 0, 0)
+        self.screen.addstr(0,5,'HYTECH RACING 2019 VEHICLE SERIAL DEBUGGER')
+        self.screen.addstr(3,5,'RMS INVERTER')
+        self.screen.addstr(4,5,'MODULE A TEMP: ')
+        self.screen.addstr(5,5,'MODULE B TEMP: ')
+        self.screen.addstr(6,5,'MODULE C TEMP: ')
+        self.screen.addstr(7,5,'GATE DRIVER BOARD TEMP: ')
+        self.screen.addstr(8,5,'RTD 4 TEMP: ')
+        self.screen.addstr(9,5,'RTD 5 TEMP: ')
+        self.screen.addstr(10,5,'MOTOR TEMP: ')
+        self.screen.addstr(11,5,'TORQUE SHUDDER: ')
+        self.screen.addstr(12,5,'MOTOR ANGLE: ')
+        self.screen.addstr(13,5,'MOTOR SPEED: ')
+        self.screen.addstr(14,5,'ELEC OUTPUT FREQ: ')
+        self.screen.addstr(15,5,'DELTA RESOLVER FILT: ')
+        self.screen.addstr(16,5,'PHASE A CURRENT: ')
+        self.screen.addstr(17,5,'PHASE B CURRENT: ')
+        self.screen.addstr(18,5,'PHASE C CURRENT: ')
+        self.screen.addstr(19,5,'DC BUS CURRENT: ')
+        self.screen.addstr(20,5,'DC BUS VOLTAGE: ')
+        self.screen.addstr(21,5,'OUTPUT VOLTAGE: ')
+        self.screen.addstr(22,5,'PHASE AB VOLTAGE: ')
+        self.screen.addstr(23,5,'PHASE BC VOLTAGE: ')
+        self.screen.addstr(24,5,'VSM STATE: ')
+        self.screen.addstr(25,5,'INVERTER STATE: ')
+        self.screen.addstr(26,5,'INVERTER RUN MODE: ')
+        self.screen.addstr(27,5,'INVERTER ACTIVE DISCHARGE STATE: ')
+        self.screen.addstr(28,5,'INVERTER COMMAND MODE: ')
+        self.screen.addstr(29,5,'INVERTER ENABLE: ')
+        self.screen.addstr(30,5,'INVERTER LOCKOUT: ')
+        self.screen.addstr(31,5,'DIRECTION COMMAND: ')
+        self.screen.addstr(32,5,'POST FAULT LO: ')
+        self.screen.addstr(33,5,'POST FAULT HI: ')
+        self.screen.addstr(34,5,'RUN FAULT LO: ')
+        self.screen.addstr(35,5,'RUN FAULT HI: ')
+        self.screen.addstr(36,5,'COMMANDED TORQUE: ')
+        self.screen.addstr(37,5,'TORQUE FEEDBACK: ')
+        self.screen.addstr(38,5,'RMS UPTIME: ')
+
+        self.screen.addstr(40,5,'GLV CURRENT READINGS')
+        self.screen.addstr(41,5,'ECU CURRENT: ')
+        self.screen.addstr(42,5,'COOLING CURRENT: ')
+
+        self.screen.addstr(3,55,'BATTERY MANAGEMENT SYSTEM')
+        self.screen.addstr(4,55,'BMS AVERAGE TEMPERATURE: ')
+        self.screen.addstr(5,55,'BMS LOW TEMPERATURE: ')
+        self.screen.addstr(6,55,'BMS HIGH TEMPERATURE: ')
+        self.screen.addstr(7,55,'BMS STATE: ')
+        self.screen.addstr(8,55,'BMS ERROR FLAGS: ')
+        self.screen.addstr(9,55,'BMS CURRENT: ')
+        self.screen.addstr(10,55,'BMS VOLTAGE AVERAGE: ')
+        self.screen.addstr(11,55,'BMS VOLTAGE LOW: ')
+        self.screen.addstr(12,55,'BMS VOLTAGE HIGH: ')
+        self.screen.addstr(13,55,'BMS VOLTAGE TOTAL: ')
+        self.screen.addstr(14,55,'BMS TOTAL CHARGE: ')
+        self.screen.addstr(15,55,'BMS TOTAL DISCHARGE: ')
+
+        if self.ecu_version == 0:
+            self.screen.addstr(17,55,'FRONT CONTROL UNIT')
+            self.screen.addstr(18,55,'FCU UPTIME: ')
+            self.screen.addstr(19,55,'FCU STATE: ')
+            self.screen.addstr(20,55,'START BUTTON ID: ')
+            self.screen.addstr(21,55,'FCU RAW TORQUE: ')
+            self.screen.addstr(22,55,'REQUESTED TORQUE: ')
+
+            self.screen.addstr(23,55,'FCU PEDAL ACCEL 1: ')
+            self.screen.addstr(24,55,'FCU PEDAL ACCEL 2: ')
+            self.screen.addstr(25,55,'FCU PEDAL BRAKE: ')
+            self.screen.addstr(26,55,'FCU BRAKE ACT: ')
+            self.screen.addstr(27,55,'FCU IMPLAUS ACCEL: ')
+            self.screen.addstr(28,55,'FCU IMPLAUS BRAKE: ')
+
+            # RCU messages are only needed if FCU is used
+            self.screen.addstr(30,55,'REAR CONTROL UNIT')
+            self.screen.addstr(31,55,'RCU UPTIME: ')
+            self.screen.addstr(32,55,'RCU STATE: ')
+            self.screen.addstr(33,55,'RCU FLAGS: ')
+            self.screen.addstr(34,55,'GLV BATT VOLTAGE: ')
+            self.screen.addstr(35,55,'RCU BMS FAULT: ')
+            self.screen.addstr(36,55,'RCU IMD FAULT: ')
+        else:
+            self.screen.addstr(17,55,'MAIN CONTROL UNIT')
+            self.screen.addstr(18,55,'MCU STATE: ')
+            self.screen.addstr(19,55,'MCU BMS FAULT: ')
+            self.screen.addstr(20,55,'MCU IMD FAULT: ')
+            self.screen.addstr(21,55,'MCU INVERTER POWER: ')
+            self.screen.addstr(22,55,'MCU SHUTDOWN ABOVE THRESH: ')
+            self.screen.addstr(23,55,'MCU TEMPERATURE: ')
+            self.screen.addstr(24,55,'MCU GLV VOLTAGE: ')
+
+            self.screen.addstr(25,55,'MCU PEDAL ACCEL 1: ')
+            self.screen.addstr(26,55,'MCU PEDAL ACCEL 2: ')
+            self.screen.addstr(27,55,'MCU PEDAL BRAKE: ')
+            self.screen.addstr(28,55,'MCU BRAKE ACT: ')
+            self.screen.addstr(29,55,'MCU IMPLAUS ACCEL: ')
+            self.screen.addstr(30,55,'MCU IMPLAUS BRAKE: ')
+            self.screen.addstr(31,55,'MCU TORQUE MAP MODE: ')
+            self.screen.addstr(32,55,'REQUESTED TORQUE: ')
+
+        self.screen.addstr(3,105,'BATTERY MANAGEMENT SYSTEM DETAILED VOLTAGES')
+        self.screen.addstr(4,105,'IC 0 CELL 0: ')
+        self.screen.addstr(5,105,'IC 0 CELL 1: ')
+        self.screen.addstr(6,105,'IC 0 CELL 2: ')
+        self.screen.addstr(7,105,'IC 0 CELL 3: ')
+        self.screen.addstr(8,105,'IC 0 CELL 4: ')
+        self.screen.addstr(9,105,'IC 0 CELL 5: ')
+        self.screen.addstr(10,105,'IC 0 CELL 6: ')
+        self.screen.addstr(11,105,'IC 0 CELL 7: ')
+        self.screen.addstr(12,105,'IC 0 CELL 8: ')
+
+        self.screen.addstr(14,105,'IC 1 CELL 0: ')
+        self.screen.addstr(15,105,'IC 1 CELL 1: ')
+        self.screen.addstr(16,105,'IC 1 CELL 2: ')
+        self.screen.addstr(17,105,'IC 1 CELL 3: ')
+        self.screen.addstr(18,105,'IC 1 CELL 4: ')
+        self.screen.addstr(19,105,'IC 1 CELL 5: ')
+        self.screen.addstr(20,105,'IC 1 CELL 6: ')
+        self.screen.addstr(21,105,'IC 1 CELL 7: ')
+        self.screen.addstr(22,105,'IC 1 CELL 8: ')
+
+        self.screen.addstr(24,105,'IC 2 CELL 0: ')
+        self.screen.addstr(25,105,'IC 2 CELL 1: ')
+        self.screen.addstr(26,105,'IC 2 CELL 2: ')
+        self.screen.addstr(27,105,'IC 2 CELL 3: ')
+        self.screen.addstr(28,105,'IC 2 CELL 4: ')
+        self.screen.addstr(29,105,'IC 2 CELL 5: ')
+        self.screen.addstr(30,105,'IC 2 CELL 6: ')
+        self.screen.addstr(31,105,'IC 2 CELL 7: ')
+        self.screen.addstr(32,105,'IC 2 CELL 8: ')
+
+        self.screen.addstr(34,105,'IC 3 CELL 0: ')
+        self.screen.addstr(35,105,'IC 3 CELL 1: ')
+        self.screen.addstr(36,105,'IC 3 CELL 2: ')
+        self.screen.addstr(37,105,'IC 3 CELL 3: ')
+        self.screen.addstr(38,105,'IC 3 CELL 4: ')
+        self.screen.addstr(39,105,'IC 3 CELL 5: ')
+        self.screen.addstr(40,105,'IC 3 CELL 6: ')
+        self.screen.addstr(41,105,'IC 3 CELL 7: ')
+        self.screen.addstr(42,105,'IC 3 CELL 8: ')
+
+        self.screen.addstr(4,130,'IC 4 CELL 0: ')
+        self.screen.addstr(5,130,'IC 4 CELL 1: ')
+        self.screen.addstr(6,130,'IC 4 CELL 2: ')
+        self.screen.addstr(7,130,'IC 4 CELL 3: ')
+        self.screen.addstr(8,130,'IC 4 CELL 4: ')
+        self.screen.addstr(9,130,'IC 4 CELL 5: ')
+        self.screen.addstr(10,130,'IC 4 CELL 6: ')
+        self.screen.addstr(11,130,'IC 4 CELL 7: ')
+        self.screen.addstr(12,130,'IC 4 CELL 8: ')
+
+        self.screen.addstr(14,130,'IC 5 CELL 0: ')
+        self.screen.addstr(15,130,'IC 5 CELL 1: ')
+        self.screen.addstr(16,130,'IC 5 CELL 2: ')
+        self.screen.addstr(17,130,'IC 5 CELL 3: ')
+        self.screen.addstr(18,130,'IC 5 CELL 4: ')
+        self.screen.addstr(19,130,'IC 5 CELL 5: ')
+        self.screen.addstr(20,130,'IC 5 CELL 6: ')
+        self.screen.addstr(21,130,'IC 5 CELL 7: ')
+        self.screen.addstr(22,130,'IC 5 CELL 8: ')
+
+        self.screen.addstr(24,130,'IC 6 CELL 0: ')
+        self.screen.addstr(25,130,'IC 6 CELL 1: ')
+        self.screen.addstr(26,130,'IC 6 CELL 2: ')
+        self.screen.addstr(27,130,'IC 6 CELL 3: ')
+        self.screen.addstr(28,130,'IC 6 CELL 4: ')
+        self.screen.addstr(29,130,'IC 6 CELL 5: ')
+        self.screen.addstr(30,130,'IC 6 CELL 6: ')
+        self.screen.addstr(31,130,'IC 6 CELL 7: ')
+        self.screen.addstr(32,130,'IC 6 CELL 8: ')
+
+        self.screen.addstr(34,130,'IC 7 CELL 0: ')
+        self.screen.addstr(35,130,'IC 7 CELL 1: ')
+        self.screen.addstr(36,130,'IC 7 CELL 2: ')
+        self.screen.addstr(37,130,'IC 7 CELL 3: ')
+        self.screen.addstr(38,130,'IC 7 CELL 4: ')
+        self.screen.addstr(39,130,'IC 7 CELL 5: ')
+        self.screen.addstr(40,130,'IC 7 CELL 6: ')
+        self.screen.addstr(41,130,'IC 7 CELL 7: ')
+        self.screen.addstr(42,130,'IC 7 CELL 8: ')
+
+        self.screen.addstr(3,155,'BATTERY MANAGEMENT SYSTEM DETAILED TEMPERATURES')
+        self.screen.addstr(4,155,'IC 0 THERM 0: ')
+        self.screen.addstr(5,155,'IC 0 THERM 1: ')
+        self.screen.addstr(6,155,'IC 0 THERM 2: ')
+
+        self.screen.addstr(8,155,'IC 1 THERM 0: ')
+        self.screen.addstr(9,155,'IC 1 THERM 1: ')
+        self.screen.addstr(10,155,'IC 1 THERM 2: ')
+
+        self.screen.addstr(12,155,'IC 2 THERM 0: ')
+        self.screen.addstr(13,155,'IC 2 THERM 1: ')
+        self.screen.addstr(14,155,'IC 2 THERM 2: ')
+
+        self.screen.addstr(16,155,'IC 3 THERM 0: ')
+        self.screen.addstr(17,155,'IC 3 THERM 1: ')
+        self.screen.addstr(18,155,'IC 3 THERM 2: ')
+
+        self.screen.addstr(4,180,'IC 4 THERM 0: ')
+        self.screen.addstr(5,180,'IC 4 THERM 1: ')
+        self.screen.addstr(6,180,'IC 4 THERM 2: ')
+
+        self.screen.addstr(8,180,'IC 5 THERM 0: ')
+        self.screen.addstr(9,180,'IC 5 THERM 1: ')
+        self.screen.addstr(10,180,'IC 5 THERM 2: ')
+
+        self.screen.addstr(12,180,'IC 6 THERM 0: ')
+        self.screen.addstr(13,180,'IC 6 THERM 1: ')
+        self.screen.addstr(14,180,'IC 6 THERM 2: ')
+
+        self.screen.addstr(16,180,'IC 7 THERM 0: ')
+        self.screen.addstr(17,180,'IC 7 THERM 1: ')
+        self.screen.addstr(18,180,'IC 7 THERM 2: ')
+
+        self.screen.addstr(20,155,'BATTERY MANAGEMENT SYSTEM BALANCING STATUS')
+        self.screen.addstr(21,160,'C0')
+        self.screen.addstr(21,165,'C1')
+        self.screen.addstr(21,170,'C2')
+        self.screen.addstr(21,175,'C3')
+        self.screen.addstr(21,180,'C4')
+        self.screen.addstr(21,185,'C5')
+        self.screen.addstr(21,190,'C6')
+        self.screen.addstr(21,195,'C7')
+        self.screen.addstr(21,200,'C8')
+        self.screen.addstr(22,155,'IC0')
+        self.screen.addstr(23,155,'IC1')
+        self.screen.addstr(24,155,'IC2')
+        self.screen.addstr(25,155,'IC3')
+        self.screen.addstr(26,155,'IC4')
+        self.screen.addstr(27,155,'IC5')
+        self.screen.addstr(28,155,'IC6')
+        self.screen.addstr(29,155,'IC7')
+
+        self.live()
+        curses.endwin()
+
+    def live(self):
+        # Set up mqtt connection
+        client = mqtt.Client()
+        client.connect("hytech-telemetry.ryangallaway.me", 1883, 60)
+        client.on_connect = self.mqtt_connect
+        client.on_message = self.mqtt_message
+        client.loop_start()
+        
+        self.screen.nodelay(True)
+
+        # Write CSV Header
+        with open(self.filenameRaw, "a") as f:
+            f.write("timestamp,CAN ID,msg\n")
+        
+        # Wait for q to quit
+        char = self.screen.getch()
+        while char != ord('q') and char != ord('Q'):
+            char = self.screen.getch()
+
+        # Time to quit, disconnect MQTT
+        client.loop_stop()
+        client.disconnect() # TODO unsure if this should be called
+
+        # Write out statistics
+        with open(self.filename, "a") as f:
+            f.write("Processed " + str(self.countGoodFrames) + " good frames - ignored " + str(self.countBadFrames) + " bad frames")
+
+    def updateScreen(self, incomingLine):
+        if ('MODULE A TEMP' in incomingLine):
+            self.clearLine(4,5)
+            self.screen.addstr(4,5,incomingLine)
+        if ('MODULE B TEMP' in incomingLine):
+            self.clearLine(5,5)
+            self.screen.addstr(5,5,incomingLine)
+        if ('MODULE C TEMP' in incomingLine):
+            self.clearLine(6,5)
+            self.screen.addstr(6,5,incomingLine)
+        if ('GATE DRIVER BOARD TEMP' in incomingLine):
+            self.clearLine(7,5)
+            self.screen.addstr(7,5,incomingLine)
+        if ('RTD 4 TEMP' in incomingLine):
+            self.clearLine(8,5)
+            self.screen.addstr(8,5,incomingLine)
+        if ('RTD 5 TEMP' in incomingLine):
+            self.clearLine(9,5)
+            self.screen.addstr(9,5,incomingLine)
+        if ('MOTOR TEMP' in incomingLine):
+            self.clearLine(10,5)
+            self.screen.addstr(10,5,incomingLine)
+        if ('TORQUE SHUDDER' in incomingLine):
+            self.clearLine(11,5)
+            self.screen.addstr(11,5,incomingLine)
+        if ('MOTOR ANGLE' in incomingLine):
+            self.clearLine(12,5)
+            self.screen.addstr(12,5,incomingLine)
+        if ('MOTOR SPEED' in incomingLine):
+            self.clearLine(13,5)
+            self.screen.addstr(13,5,incomingLine)
+        if ('ELEC OUTPUT FREQ' in incomingLine):
+            self.clearLine(14,5)
+            self.screen.addstr(14,5,incomingLine)
+        if ('DELTA RESOLVER FILT' in incomingLine):
+            self.clearLine(15,5)
+            self.screen.addstr(15,5,incomingLine)
+        if ('PHASE A CURRENT' in incomingLine):
+            self.clearLine(16,5)
+            self.screen.addstr(16,5,incomingLine)
+        if ('PHASE B CURRENT' in incomingLine):
+            self.clearLine(17,5)
+            self.screen.addstr(17,5,incomingLine)
+        if ('PHASE C CURRENT' in incomingLine):
+            self.clearLine(18,5)
+            self.screen.addstr(18,5,incomingLine)
+        if ('DC BUS CURRENT' in incomingLine):
+            self.clearLine(19,5)
+            self.screen.addstr(19,5,incomingLine)
+        if ('DC BUS VOLTAGE' in incomingLine):
+            self.clearLine(20,5)
+            self.screen.addstr(20,5,incomingLine)
+        if ('OUTPUT VOLTAGE' in incomingLine):
+            self.clearLine(21,5)
+            self.screen.addstr(21,5,incomingLine)
+        if ('PHASE AB VOLTAGE' in incomingLine):
+            self.clearLine(22,5)
+            self.screen.addstr(22,5,incomingLine)
+        if ('PHASE BC VOLTAGE' in incomingLine):
+            self.clearLine(23,5)
+            self.screen.addstr(23,5,incomingLine)
+        if ('VSM STATE' in incomingLine):
+            self.clearLine(24,5)
+            self.screen.addstr(24,5,incomingLine)
+        if ('INVERTER STATE' in incomingLine):
+            self.clearLine(25,5)
+            self.screen.addstr(25,5,incomingLine)
+        if ('INVERTER RUN MODE' in incomingLine):
+            self.clearLine(26,5)
+            self.screen.addstr(26,5,incomingLine)
+        if ('INVERTER ACTIVE DISCHARGE STATE' in incomingLine):
+            self.clearLine(27,5)
+            self.screen.addstr(27,5,incomingLine)
+        if ('INVERTER COMMAND MODE' in incomingLine):
+            self.clearLine(28,5)
+            self.screen.addstr(28,5,incomingLine)
+        if ('INVERTER ENABLE' in incomingLine):
+            self.clearLine(29,5)
+            self.screen.addstr(29,5,incomingLine)
+        if ('INVERTER LOCKOUT' in incomingLine):
+            self.clearLine(30,5)
+            self.screen.addstr(30,5,incomingLine)
+        if ('DIRECTION COMMAND' in incomingLine):
+            self.clearLine(31,5)
+            self.screen.addstr(31,5,incomingLine)
+        if ('POST FAULT LO' in incomingLine):
+            self.clearLine(32,5)
+            self.screen.addstr(32,5,incomingLine)
+        if ('POST FAULT HI' in incomingLine):
+            self.clearLine(33,5)
+            self.screen.addstr(33,5,incomingLine)
+        if ('RUN FAULT LO' in incomingLine):
+            self.clearLine(34,5)
+            self.screen.addstr(34,5,incomingLine)
+        if ('RUN FAULT HI' in incomingLine):
+            self.clearLine(35,5)
+            self.screen.addstr(35,5,incomingLine)
+        if ('COMMANDED TORQUE:' in incomingLine):
+            self.clearLine(36,5)
+            self.screen.addstr(36,5,incomingLine)
+        if ('TORQUE FEEDBACK' in incomingLine):
+            self.clearLine(37,5)
+            self.screen.addstr(37,5,incomingLine)
+        if ('RMS UPTIME' in incomingLine):
+            self.clearLine(38,5)
+            self.screen.addstr(38,5,incomingLine)
+        if ('ECU CURRENT' in incomingLine):
+            self.clearLine(41,5)
+            self.screen.addstr(41,5,incomingLine)
+        if ('COOLING CURRENT' in incomingLine):
+            self.clearLine(42,5)
+            self.screen.addstr(42,5,incomingLine)
+        if ('BMS AVERAGE TEMPERATURE' in incomingLine):
+            self.clearLine(4,55)
+            self.screen.addstr(4,55,incomingLine)
+        if ('BMS LOW TEMPERATURE' in incomingLine):
+            self.clearLine(5,55)
+            self.screen.addstr(5,55,incomingLine)
+        if ('BMS HIGH TEMPERATURE' in incomingLine):
+            self.clearLine(6,55)
+            self.screen.addstr(6,55,incomingLine)
+        if ('BMS STATE' in incomingLine):
+            self.clearLine(7,55)
+            self.screen.addstr(7,55,incomingLine)
+        if ('BMS ERROR FLAGS' in incomingLine):
+            self.clearLine(8,55)
+            self.screen.addstr(8,55,incomingLine)
+        if ('BMS CURRENT' in incomingLine):
+            self.clearLine(9,55)
+            self.screen.addstr(9,55,incomingLine)
+        if ('BMS VOLTAGE AVERAGE' in incomingLine):
+            self.clearLine(10,55)
+            self.screen.addstr(10,55,incomingLine)
+        if ('BMS VOLTAGE LOW' in incomingLine):
+            self.clearLine(11,55)
+            self.screen.addstr(11,55,incomingLine)
+        if ('BMS VOLTAGE HIGH' in incomingLine):
+            self.clearLine(12,55)
+            self.screen.addstr(12,55,incomingLine)
+        if ('BMS VOLTAGE TOTAL' in incomingLine):
+            self.clearLine(13,55)
+            self.screen.addstr(13,55,incomingLine)
+        if ('BMS TOTAL CHARGE' in incomingLine):
+            self.clearLine(14,55)
+            self.screen.addstr(14,55,incomingLine)
+        if ('BMS TOTAL DISCHARGE' in incomingLine):
+            self.clearLine(15,55)
+            self.screen.addstr(15,55,incomingLine)
+        if ('FCU UPTIME' in incomingLine or 'MCU STATE' in incomingLine):
+            self.clearLine(18,55)
+            self.screen.addstr(18,55,incomingLine)
+        if ('FCU STATE' in incomingLine or 'MCU BMS FAULT' in incomingLine):
+            self.clearLine(19,55)
+            self.screen.addstr(19,55,incomingLine)
+        if ('FCU START BUTTON ID' in incomingLine or 'MCU IMD FAULT' in incomingLine):
+            self.clearLine(20,55)
+            self.screen.addstr(20,55,incomingLine)
+        if ('FCU RAW TORQUE' in incomingLine or 'MCU INVERTER POWER' in incomingLine):
+            self.clearLine(21,55)
+            self.screen.addstr(21,55,incomingLine)
+        if ('REQUESTED TORQUE' in incomingLine):
+            if self.ecu_version == 0:
+                self.clearLine(22,55)
+                self.screen.addstr(22,55,incomingLine)
+            else:
+                self.clearLine(32,55)
+                self.screen.addstr(32,55,incomingLine)
+        if ('MCU SHUTDOWN ABOVE THRESH' in incomingLine):
+            self.clearLine(22,55)
+            self.screen.addstr(22,55,incomingLine)
+        if ('FCU PEDAL ACCEL 1' in incomingLine or 'MCU TEMPERATURE' in incomingLine):
+            self.clearLine(23,55)
+            self.screen.addstr(23,55,incomingLine)
+        if ('FCU PEDAL ACCEL 2' in incomingLine or 'MCU GLV VOLTAGE' in incomingLine):
+            self.clearLine(24,55)
+            self.screen.addstr(24,55,incomingLine)
+        if ('FCU PEDAL BRAKE' in incomingLine or 'MCU PEDAL ACCEL 1' in incomingLine):
+            self.clearLine(25,55)
+            self.screen.addstr(25,55,incomingLine)
+        if ('FCU BRAKE ACT' in incomingLine or 'MCU PEDAL ACCEL 2' in incomingLine):
+            self.clearLine(26,55)
+            self.screen.addstr(26,55,incomingLine)
+        if ('FCU IMPLAUS ACCEL' in incomingLine or 'MCU PEDAL BRAKE' in incomingLine):
+            self.clearLine(27,55)
+            self.screen.addstr(27,55,incomingLine)
+        if ('FCU IMPLAUS BRAKE' in incomingLine or 'MCU BRAKE ACT' in incomingLine):
+            self.clearLine(28,55)
+            self.screen.addstr(28,55,incomingLine)
+        if ('MCU IMPLAUS ACCEL' in incomingLine):
+            self.clearLine(29, 55)
+            self.screen.addstr(29, 55, incomingLine)
+        if ('MCU IMPLAUS BRAKE' in incomingLine):
+            self.clearLine(30, 55)
+            self.screen.addstr(30, 55, incomingLine)
+        if ('RCU UPTIME' in incomingLine or 'MCU TORQUE MAP MODE' in incomingLine):
+            self.clearLine(31,55)
+            self.screen.addstr(31,55,incomingLine)
+        if ('RCU STATE' in incomingLine):
+            self.clearLine(32,55)
+            self.screen.addstr(32,55,incomingLine)
+        if ('RCU FLAGS' in incomingLine):
+            self.clearLine(33,55)
+            self.screen.addstr(33,55,incomingLine)
+        if ('GLV BATT VOLTAGE' in incomingLine):
+            self.clearLine(34,55)
+            self.screen.addstr(34,55,incomingLine)
+        if ('RCU BMS FAULT' in incomingLine):
+            self.clearLine(35,55)
+            self.screen.addstr(35,55,incomingLine)
+        if ('RCU IMD FAULT' in incomingLine):
+            self.clearLine(36,55)
+            self.screen.addstr(36,55,incomingLine)
+        if ('IC 0 C' in incomingLine):
+            row = 4 + int(incomingLine[10])
+            self.clearLineShort(row,105)
+            self.screen.addstr(row,105,incomingLine)
+        if ('IC 1 C' in incomingLine):
+            row = 14 + int(incomingLine[10])
+            self.clearLineShort(row,105)
+            self.screen.addstr(row,105,incomingLine)
+        if ('IC 2 C' in incomingLine):
+            row = 24 + int(incomingLine[10])
+            self.clearLineShort(row,105)
+            self.screen.addstr(row,105,incomingLine)
+        if ('IC 3 C' in incomingLine):
+            row = 34 + int(incomingLine[10])
+            self.clearLineShort(row,105)
+            self.screen.addstr(row,105,incomingLine)
+        if ('IC 4 C' in incomingLine):
+            row = 4 + int(incomingLine[10])
+            self.clearLineShort(row,130)
+            self.screen.addstr(row,130,incomingLine)
+        if ('IC 5 C' in incomingLine):
+            row = 14 + int(incomingLine[10])
+            self.clearLineShort(row,130)
+            self.screen.addstr(row,130,incomingLine)
+        if ('IC 6 C' in incomingLine):
+            row = 24 + int(incomingLine[10])
+            self.clearLineShort(row,130)
+            self.screen.addstr(row,130,incomingLine)
+        if ('IC 7 C' in incomingLine):
+            row = 34 + int(incomingLine[10])
+            self.clearLineShort(row,130)
+            self.screen.addstr(row,130,incomingLine)
+        if ('IC 0 T' in incomingLine):
+            row = 4 + int(incomingLine[11])
+            self.clearLineShort(row,155)
+            self.screen.addstr(row,155,incomingLine)
+        if ('IC 1 T' in incomingLine):
+            row = 8 + int(incomingLine[11])
+            self.clearLineShort(row,155)
+            self.screen.addstr(row,155,incomingLine)
+        if ('IC 2 T' in incomingLine):
+            row = 12 + int(incomingLine[11])
+            self.clearLineShort(row,155)
+            self.screen.addstr(row,155,incomingLine)
+        if ('IC 3 T' in incomingLine):
+            row = 16 + int(incomingLine[11])
+            self.clearLineShort(row,155)
+            self.screen.addstr(row,155,incomingLine)
+        if ('IC 4 T' in incomingLine):
+            row = 4 + int(incomingLine[11])
+            self.clearLineShort(row,180)
+            self.screen.addstr(row,180,incomingLine)
+        if ('IC 5 T' in incomingLine):
+            row = 8 + int(incomingLine[11])
+            self.clearLineShort(row,180)
+            self.screen.addstr(row,180,incomingLine)
+        if ('IC 6 T' in incomingLine):
+            row = 12 + int(incomingLine[11])
+            self.clearLineShort(row,180)
+            self.screen.addstr(row,180,incomingLine)
+        if ('IC 7 T' in incomingLine):
+            row = 16 + int(incomingLine[11])
+            self.clearLineShort(row,180)
+            self.screen.addstr(row,180,incomingLine)
+        if ('BAL' in incomingLine): # format: BAL IC# CELL# [ON|OFF]
+            row = 22 + int(incomingLine[incomingLine.index('IC') + 2])
+            col = 160 + (int(incomingLine[incomingLine.index('CELL') + 4]) * 5)
+            self.clearLineBal(row, col)
+            if 'ON' in incomingLine:
+                self.screen.addstr(row, col, 'BAL')
+        self.screen.refresh()
+
+    def clearLine(self, y, x):
+        blanks = '                                                  '
+        self.screen.addstr(y,x,blanks)
+
+    def clearLineShort(self, y, x):
+        blanks = '                      '
+        self.screen.addstr(y,x,blanks)
+
+    def clearLineBal(self, y, x):
+        blanks = '   '
+        self.screen.addstr(y,x,blanks)
 
 def unpack(frame):
     #print("----------------")
@@ -839,4 +836,11 @@ def fletcher16(data):
     c1 %= 255
     return (c1 << 8 | c0)
 
-main()
+
+if len(sys.argv) != 2:
+    print('Usage:')
+    print('telemetry_lte_xbee.py [fcu|mcu]\n')
+    quit()
+
+telemClient = TelemetryClient()
+curses.wrapper(telemClient.setupScreen)


### PR DESCRIPTION
The diff looks like I rewrote the entire file, but all I really did was add some indentation and `self.` throughout the file. 

The whole thing is now a class with proper instance variables to keep track of the `screen` instance. The `curses.wrapper` call was relocated to give it a wider scope, so exceptions during the initial setup of the screen will not cause the corrupted terminal issue.